### PR TITLE
Fix: Stop requesting notifications on unload

### DIFF
--- a/custom_components/etekcitybp_ble/__init__.py
+++ b/custom_components/etekcitybp_ble/__init__.py
@@ -71,13 +71,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: EtekcityConfigEntry) -> 
 
     return True
 
-async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _async_update_listener(hass: HomeAssistant, entry: EtekcityConfigEntry) -> None:
     """Handle options update."""
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: EtekcityConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(
-        entry, PLATFORMS
-    )
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        coordinator = entry.runtime_data
+        if coordinator is not None:
+            await coordinator.async_unload_entry()
+    return unload_ok

--- a/custom_components/etekcitybp_ble/coordinator.py
+++ b/custom_components/etekcitybp_ble/coordinator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 
 from bleak import BleakClient
@@ -30,9 +29,6 @@ from .const import (
 )
 from .device import EtekcityBPDevice
 
-
-if TYPE_CHECKING:
-    from bleak.backends.device import BLEDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,7 +66,6 @@ class EtekcityBPCoordinator(
         self.device = device
         self.device_name = device_name
         self.base_unique_id = base_unique_id
-        # self._ready_event = asyncio.Event()
 
         _LOGGER.debug(f"Scanner count: {bluetooth.async_scanner_count(hass, connectable=True)}")
         if bluetooth.async_scanner_count(hass, connectable=True) < 1:
@@ -101,7 +96,6 @@ class EtekcityBPCoordinator(
         # This method is called when the coordinator is updated.
         # It can be used to update the device state or perform other actions.
         _LOGGER.info("Device %s is now available", self.device_name)
-        # self._ready_event.set()
 
     async def _async_update(
         self, service_info: bluetooth.BluetoothServiceInfoBleak
@@ -163,7 +157,6 @@ class EtekcityBPCoordinator(
     ) -> None:
         """Handle the device going unavailable."""
         super()._async_handle_unavailable(service_info)
-        self._available = False
         _LOGGER.info("Device %s is unavailable", self.device_name)
 
 
@@ -185,3 +178,8 @@ class EtekcityBPCoordinator(
             )
         ):
             return
+
+    async def async_unload_entry(self) -> bool:
+        """Unload a config entry."""
+        self._available = False
+        return True

--- a/custom_components/etekcitybp_ble/manifest.json
+++ b/custom_components/etekcitybp_ble/manifest.json
@@ -15,5 +15,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/EdLeckert/ha_etekcity_blood_pressure_monitor/issues",
   "requirements": [],
-  "version": "1.0.0"
+  "version": "1.0.1"
 }


### PR DESCRIPTION
Integration does not stop communicating with device on unload. This fix disables connection and notification requests on unload.